### PR TITLE
Update snapshot version in Readme.MD to fix missing class in jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repository {
 
 dependency {
     // Include the sdk as a dependency
-    compile('com.microsoft.graph:microsoft-graph-auth:0.1.0-SNAPSHOT')
+    compile('com.microsoft.graph:microsoft-graph-auth:0.2.0-SNAPSHOT')
 }
 ```
 
@@ -32,7 +32,7 @@ Add the dependency in `dependencies` in pom.xml
 <dependency>
 	<groupId>com.microsoft.graph</groupId>
 	<artifactId>microsoft-graph-auth</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The new snapshot seems to have fixed the issue highlighted in #20 and the other duplicate threads regarding misplaced or missing classes. 
I didn't know about this new snapshot until I browsed the nexus repository myself. 